### PR TITLE
Use `exec` syscall on Unix

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,13 +3,11 @@ use std::{env::var, path::PathBuf, process::Command, vec::Vec};
 use jwalk::WalkDir;
 use which::which;
 
-
 const TARGETS_ENV: &str = "WRAPPE_TARGETS";
 const FILES_ENV: &str = "WRAPPE_FILES";
 const NO_CROSS_ENV: &str = "WRAPPE_NO_CROSS";
 const OSXCROSS_WORKAROUND_ENV: &str = "WRAPPE_OSXCROSS_WORKAROUND";
 const STARTER_NAME: &str = "startpe";
-
 
 fn get_runner_targets() -> Vec<String> {
     let rustc = var("RUSTC").unwrap();

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -29,9 +29,13 @@ pub struct HashReader<R: Read, H: Hasher> {
     hasher: H,
 }
 impl<R: Read, H: Hasher> HashReader<R, H> {
-    pub fn new(reader: R, hasher: H) -> Self { HashReader { reader, hasher } }
+    pub fn new(reader: R, hasher: H) -> Self {
+        HashReader { reader, hasher }
+    }
 
-    pub fn finish(self) -> u64 { self.hasher.finish() }
+    pub fn finish(self) -> u64 {
+        self.hasher.finish()
+    }
 }
 impl<R: Read, H: Hasher> Read for HashReader<R, H> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
@@ -131,7 +135,7 @@ pub fn compress<
             let mut name_array = [0; NAME_SIZE];
             name_array[0..name.len()].copy_from_slice(name.as_bytes());
             directories.push(DirectorySection {
-                name:   name_array,
+                name: name_array,
                 parent: parent as u32,
             });
 
@@ -426,16 +430,16 @@ pub fn compress<
             let mut name_array = [0; NAME_SIZE];
             name_array[0..name.len()].copy_from_slice(name.as_bytes());
             let mut header = SymlinkSection {
-                name:                  name_array,
-                parent:                parent as u32,
-                kind:                  is_file as u8,
-                target:                target as u32,
-                time_accessed_nanos:   0,
+                name: name_array,
+                parent: parent as u32,
+                kind: is_file as u8,
+                target: target as u32,
+                time_accessed_nanos: 0,
                 time_accessed_seconds: 0,
-                time_modified_nanos:   0,
+                time_modified_nanos: 0,
                 time_modified_seconds: 0,
-                mode:                  0,
-                readonly:              0,
+                mode: 0,
+                readonly: 0,
             };
 
             if let Ok(ref meta) = meta {
@@ -487,12 +491,12 @@ pub fn compress<
         target.write_all(section.as_bytes()).unwrap();
     }
     let payload_header = PayloadHeader {
-        kind:               0,
+        kind: 0,
         directory_sections: directories.len(),
-        file_sections:      files.lock().unwrap().len(),
-        symlink_sections:   symlinks.lock().unwrap().len(),
-        section_hash:       hasher.finish(),
-        payload_size:       end - zero,
+        file_sections: files.lock().unwrap().len(),
+        symlink_sections: symlinks.lock().unwrap().len(),
+        section_hash: hasher.finish(),
+        payload_size: end - zero,
     };
     target.write_all(payload_header.as_bytes()).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,47 +26,47 @@ use args::*;
 pub struct Args {
     /// Zstd compression level (0-21)
     #[clap(short = 'c', long, default_value = "8")]
-    compression:      u32,
+    compression: u32,
     /// Which runner to use
     #[clap(short = 'r', long, default_value = "native")]
-    runner:           String,
+    runner: String,
     /// Unpack directory target (temp, local, cwd)
     #[clap(short = 't', long, default_value = "temp")]
-    unpack_target:    String,
+    unpack_target: String,
     /// Unpack directory name [default: inferred from input directory]
     #[clap(short = 'd', long)]
     unpack_directory: Option<String>,
     /// Versioning strategy (sidebyside, replace, none)
     #[clap(short = 'v', long, default_value = "sidebyside")]
-    versioning:       String,
+    versioning: String,
     /// Version specifier override [default: randomly generated]
     #[clap(short = 'V', long)]
-    version:          Option<String>,
+    version: Option<String>,
     /// Verification of existing unpacked data (existence, checksum, none)
     #[clap(short = 'e', long, default_value = "existence")]
-    verification:     String,
+    verification: String,
     /// Information output details (title, verbose, none)
     #[clap(short = 'i', long, default_value = "title")]
     show_information: String,
     /// Prints available runners
     #[clap(short = 'l', long)]
     #[allow(dead_code)]
-    list_runners:     bool,
+    list_runners: bool,
     /// Unconditionally show a console window on Windows
     #[clap(short = 's', long)]
-    show_console:     bool,
+    show_console: bool,
     /// Set the current dir of the target to the unpack directory
     #[clap(short = 'w', long)]
-    current_dir:      bool,
+    current_dir: bool,
     /// Path to the input directory
     #[clap(name = "input", parse(from_os_str))]
-    input:            PathBuf,
+    input: PathBuf,
     /// Path to the executable to start after unpacking
     #[clap(name = "command", parse(from_os_str))]
-    command:          PathBuf,
+    command: PathBuf,
     /// Path to or filename of the output executable
     #[clap(name = "output", parse(from_os_str))]
-    output:           PathBuf,
+    output: PathBuf,
 }
 
 fn main() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -6,28 +6,28 @@ pub const NAME_SIZE: usize = 128;
 #[repr(C, packed)]
 #[derive(AsBytes)]
 pub struct StarterInfo {
-    pub signature:        [u8; 8],
-    pub show_console:     u8,
-    pub current_dir:      u8,
-    pub verification:     u8,
+    pub signature: [u8; 8],
+    pub show_console: u8,
+    pub current_dir: u8,
+    pub verification: u8,
     pub show_information: u8,
-    pub uid:              [u8; 16],
-    pub unpack_target:    u8,
-    pub versioning:       u8,
-    pub wrappe_format:    u8,
+    pub uid: [u8; 16],
+    pub unpack_target: u8,
+    pub versioning: u8,
+    pub wrappe_format: u8,
     pub unpack_directory: [u8; NAME_SIZE],
-    pub command:          [u8; NAME_SIZE],
+    pub command: [u8; NAME_SIZE],
 }
 
 #[repr(C, packed)]
 #[derive(AsBytes)]
 pub struct PayloadHeader {
-    pub kind:               u8,
+    pub kind: u8,
     pub directory_sections: usize,
-    pub file_sections:      usize,
-    pub symlink_sections:   usize,
-    pub section_hash:       u64,
-    pub payload_size:       u64,
+    pub file_sections: usize,
+    pub symlink_sections: usize,
+    pub section_hash: u64,
+    pub payload_size: u64,
 }
 impl PayloadHeader {
     pub fn len(&self) -> usize {
@@ -37,36 +37,36 @@ impl PayloadHeader {
 #[repr(C, packed)]
 #[derive(AsBytes)]
 pub struct DirectorySection {
-    pub name:   [u8; NAME_SIZE],
+    pub name: [u8; NAME_SIZE],
     pub parent: u32,
 }
 #[repr(C, packed)]
 #[derive(AsBytes)]
 pub struct FileSectionHeader {
-    pub position:              u64,
-    pub size:                  u64,
-    pub name:                  [u8; NAME_SIZE],
-    pub parent:                u32,
-    pub file_hash:             u64,
-    pub compressed_hash:       u64,
+    pub position: u64,
+    pub size: u64,
+    pub name: [u8; NAME_SIZE],
+    pub parent: u32,
+    pub file_hash: u64,
+    pub compressed_hash: u64,
     pub time_accessed_seconds: u64,
-    pub time_accessed_nanos:   u32,
+    pub time_accessed_nanos: u32,
     pub time_modified_seconds: u64,
-    pub time_modified_nanos:   u32,
-    pub mode:                  u32,
-    pub readonly:              u8,
+    pub time_modified_nanos: u32,
+    pub mode: u32,
+    pub readonly: u8,
 }
 #[repr(C, packed)]
 #[derive(AsBytes)]
 pub struct SymlinkSection {
-    pub name:                  [u8; NAME_SIZE],
-    pub parent:                u32,
-    pub kind:                  u8,
-    pub target:                u32,
+    pub name: [u8; NAME_SIZE],
+    pub parent: u32,
+    pub kind: u8,
+    pub target: u32,
     pub time_accessed_seconds: u64,
-    pub time_accessed_nanos:   u32,
+    pub time_accessed_nanos: u32,
     pub time_modified_seconds: u64,
-    pub time_modified_nanos:   u32,
-    pub mode:                  u32,
-    pub readonly:              u8,
+    pub time_modified_nanos: u32,
+    pub mode: u32,
+    pub readonly: u8,
 }

--- a/startpe/src/decompress.rs
+++ b/startpe/src/decompress.rs
@@ -27,9 +27,13 @@ pub struct HashReader<R: Read, H: Hasher> {
     hasher: H,
 }
 impl<R: Read, H: Hasher> HashReader<R, H> {
-    pub fn new(reader: R, hasher: H) -> Self { HashReader { reader, hasher } }
+    pub fn new(reader: R, hasher: H) -> Self {
+        HashReader { reader, hasher }
+    }
 
-    pub fn finish(self) -> u64 { self.hasher.finish() }
+    pub fn finish(self) -> u64 {
+        self.hasher.finish()
+    }
 }
 impl<R: Read, H: Hasher> Read for HashReader<R, H> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {

--- a/startpe/src/types.rs
+++ b/startpe/src/types.rs
@@ -6,28 +6,28 @@ pub const NAME_SIZE: usize = 128;
 #[repr(C, packed)]
 #[derive(FromBytes)]
 pub struct StarterInfo {
-    pub signature:        [u8; 8],
-    pub show_console:     u8,
-    pub current_dir:      u8,
-    pub verification:     u8,
+    pub signature: [u8; 8],
+    pub show_console: u8,
+    pub current_dir: u8,
+    pub verification: u8,
     pub show_information: u8,
-    pub uid:              [u8; 16],
-    pub unpack_target:    u8,
-    pub versioning:       u8,
-    pub wrappe_format:    u8,
+    pub uid: [u8; 16],
+    pub unpack_target: u8,
+    pub versioning: u8,
+    pub wrappe_format: u8,
     pub unpack_directory: [u8; NAME_SIZE],
-    pub command:          [u8; NAME_SIZE],
+    pub command: [u8; NAME_SIZE],
 }
 
 #[repr(C, packed)]
 #[derive(FromBytes)]
 pub struct PayloadHeader {
-    pub kind:               u8,
+    pub kind: u8,
     pub directory_sections: usize,
-    pub file_sections:      usize,
-    pub symlink_sections:   usize,
-    pub section_hash:       u64,
-    pub payload_size:       u64,
+    pub file_sections: usize,
+    pub symlink_sections: usize,
+    pub section_hash: u64,
+    pub payload_size: u64,
 }
 impl PayloadHeader {
     pub fn len(&self) -> usize {
@@ -37,36 +37,36 @@ impl PayloadHeader {
 #[repr(C, packed)]
 #[derive(FromBytes)]
 pub struct DirectorySection {
-    pub name:   [u8; NAME_SIZE],
+    pub name: [u8; NAME_SIZE],
     pub parent: u32,
 }
 #[repr(C, packed)]
 #[derive(FromBytes)]
 pub struct FileSectionHeader {
-    pub position:              u64,
-    pub size:                  u64,
-    pub name:                  [u8; NAME_SIZE],
-    pub parent:                u32,
-    pub file_hash:             u64,
-    pub compressed_hash:       u64,
+    pub position: u64,
+    pub size: u64,
+    pub name: [u8; NAME_SIZE],
+    pub parent: u32,
+    pub file_hash: u64,
+    pub compressed_hash: u64,
     pub time_accessed_seconds: u64,
-    pub time_accessed_nanos:   u32,
+    pub time_accessed_nanos: u32,
     pub time_modified_seconds: u64,
-    pub time_modified_nanos:   u32,
-    pub mode:                  u32,
-    pub readonly:              u8,
+    pub time_modified_nanos: u32,
+    pub mode: u32,
+    pub readonly: u8,
 }
 #[repr(C, packed)]
 #[derive(FromBytes)]
 pub struct SymlinkSection {
-    pub name:                  [u8; NAME_SIZE],
-    pub parent:                u32,
-    pub kind:                  u8,
-    pub target:                u32,
+    pub name: [u8; NAME_SIZE],
+    pub parent: u32,
+    pub kind: u8,
+    pub target: u32,
     pub time_accessed_seconds: u64,
-    pub time_accessed_nanos:   u32,
+    pub time_accessed_nanos: u32,
     pub time_modified_seconds: u64,
-    pub time_modified_nanos:   u32,
-    pub mode:                  u32,
-    pub readonly:              u8,
+    pub time_modified_nanos: u32,
+    pub mode: u32,
+    pub readonly: u8,
 }


### PR DESCRIPTION
**Change description**
Currently the wrapper process ends before the child. On Unix systems the result in shells like Bash the child process continuing to run in the background (potentially using stdout/stderr, which ends up being mixed with the prompt and later command invocations).

To address this, I've added a conditional block for Unix systems (technically "not windows") which uses the `exec` syscall which replaces the current process with that of the child.

**Related issues**
- #5

**Additional context**
I'm using Wrappe to turn some lightweight NodeJS tool scripts into more portable binaries that are easier to use with the [Please](https://please.build) build system. The role Wrappe plays here is that of a bootstrapper, long term much (but likely not all) of the usage will be replaced but better optimised tools.

The important thing here is that early exists break the build (it believes output generation has completed, but during verification finds none).

## TODO

- [x] Fix line ending changes and/or determine cause.
- [ ] ~Remove `forwarded args` logging, or move into separate PR.~
      ~Was added to help debug me neglecting to add `$@` in a bash script 🤦~
     It stays!
- [x] Test behaviour on Windows.
  ~Has same issue!~
  Maybe not? Looks like the odd behaviour I'm seeing is part of a different problem. Out of scope for this PR.
- [x] Test behaviour on Linux.
- [x] Test behaviour on MacOS.